### PR TITLE
Hide compass when the rest of the UI disappears fix & version update server message

### DIFF
--- a/ext/client/__init__.lua
+++ b/ext/client/__init__.lua
@@ -39,8 +39,12 @@ Events:Subscribe('UI:DrawHud', function()
   -- get player
   local player = PlayerManager:GetLocalPlayer()
   if player == nil or player.soldier == nil then
-    uiEnabled:Update(false)
-    return
+    if isKilled then
+      uiEnabled:Update(false)
+      return
+    end
+  else
+    isKilled = false
   end
 
   uiEnabled:Update(isHud and true)

--- a/ext/client/ui.lua
+++ b/ext/client/ui.lua
@@ -1,6 +1,7 @@
 uiYaw = CachedJsExecutor('vext.setYaw', 0)
 uiEnabled = CachedJsExecutor('vext.setEnabled', false)
 isHud = false
+isKilled = false
 
 Hooks:Install('UI:PushScreen', 999, function(hook, screen, graphPriority, parentGraph)
   local screen = UIGraphAsset(screen)
@@ -21,5 +22,9 @@ Hooks:Install('UI:PushScreen', 999, function(hook, screen, graphPriority, parent
   if screen.name == 'UI/Flow/Screen/HudMPScreen' then
     uiEnabled:Update(true)
     isHud = true
+  end
+  
+  if screen.name == 'UI/Flow/Screen/KillScreen' then
+    isKilled = true
   end
 end)

--- a/ext/server/__init__.lua
+++ b/ext/server/__init__.lua
@@ -1,3 +1,5 @@
+require('updateCheck')
+
 RCON:RegisterCommand('compass.SetPosition', RemoteCommandFlag.RequiresLogin, function(command, args, loggedIn)
   local position = args[1]
 

--- a/ext/server/updateCheck.lua
+++ b/ext/server/updateCheck.lua
@@ -1,0 +1,46 @@
+-- Code from https://gitlab.com/n4gi0s/vu-mapvote by N4gi0s
+-- Modified for general use by GreatApo
+
+
+-- Add current mod version
+local localModVersion = "1.0.6" --temp fix, waiting for API to get version from mod.json
+-- Project URL
+local projectURL = "https://github.com/kapraran/vu-compass"
+-- Add check URL
+local checkURL = "https://raw.githubusercontent.com/kapraran/vu-compass/master/mod.json"
+
+-- Show up-to-date message
+local showUptodateMsg = true
+
+-- Check last version code
+function getCurrentVersion()
+	options = HttpOptions({}, 10);
+	options.verifyCertificate = false; --ignore cert for wine users
+	res = Net:GetHTTP(checkURL, options);
+	if res.status ~= 200 then
+		return nil;
+	end
+	json = json.decode(res.body);
+	
+	if json.Version ~= nil then
+		return json.Version;
+	elseif json.tag_name ~= nil then
+		return json.tag_name:gsub(" ", ""):gsub("^v", "")
+	else
+		return nil
+	end
+end
+
+function checkVersion()
+	local currentVersion = getCurrentVersion()
+	
+	if currentVersion == nil then
+		print("Could not verify if this mod is out of date. You can check manually at " .. projectURL);
+    elseif currentVersion ~= localModVersion then
+		print("This mod seems to be out of date! Please visit " .. projectURL);
+    elseif currentVersion == localModVersion and showUptodateMsg then
+		print("This mod is up-to-date (version " .. currentVersion .. ")");
+	end
+end
+
+checkVersion();


### PR DESCRIPTION
The compass is hidden when the player is killed while the rest of the UI is hidden when the killcam is triggered. This fix hides the compass along with the rest of the UI.

Additionally, it gives you the ability to report the location of the opponent (provided that your screen doesn't rotate a lot). Tested only through "suicide". 

Added server code to check for available updates and display a message in server console.